### PR TITLE
Add wavelength dependence to phase shifter model

### DIFF
--- a/lnoi400/models.py
+++ b/lnoi400/models.py
@@ -308,7 +308,7 @@ def eo_phase_shifter(
 ) -> sax.SDict:
     # Default V_pi
     if np.isnan(V_pi):
-        V_pi = 2 * 3.3e4 / length
+        V_pi = 2 * 3.3e4 * wl / length / wl_0
     v = V_dc / V_pi
 
     # Effective index at the operation frequency


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add wavelength dependence to the phase shifter model by adjusting the V_pi calculation to include wavelength parameters.

Enhancements:
- Introduce wavelength dependence to the phase shifter model by modifying the calculation of V_pi.

<!-- Generated by sourcery-ai[bot]: end summary -->