### PR TITLE
Directional couplers corrected

### DIFF
--- a/lnoi400/cells.py
+++ b/lnoi400/cells.py
@@ -1002,7 +1002,7 @@ def directional_coupler_balanced(
     coupl_wg_sep: float = 0.8,
     coup_wg_width: float = 0.8,
     cross_section_io: CrossSectionSpec = "xs_rwg1000",
-    coupling_section_width: float = 0.8,
+
 ) -> gf.Component:
     """Returns a 50-50 directional coupler.
 
@@ -1029,7 +1029,7 @@ def directional_coupler_balanced(
     cross_section_io = gf.get_cross_section(cross_section_io)
 
     s_height = (
-        io_wg_sep - coupl_wg_sep - coupling_section_width
+        io_wg_sep - coupl_wg_sep -  coup_wg_width
     ) / 2  # take into account the width of the waveguide
     size = (sbend_length, s_height)
 
@@ -1045,7 +1045,7 @@ def directional_coupler_balanced(
     c_tr = dc << bend_S_spline_varying_width(**settings_s_bend)
     c_tr.dmove(
         c_tr.ports["o1"].dcenter,
-        (central_straight_length / 2, 0.5 * (coupl_wg_sep + coupling_section_width)),
+        (central_straight_length / 2, 0.5 * (coupl_wg_sep +  coup_wg_width)),
     )
 
     # bottom right branch
@@ -1053,7 +1053,7 @@ def directional_coupler_balanced(
     c_br.dmirror_y()
     c_br.dmove(
         c_br.ports["o1"].dcenter,
-        (central_straight_length / 2, -0.5 * (coupl_wg_sep + coupling_section_width)),
+        (central_straight_length / 2, -0.5 * (coupl_wg_sep +  coup_wg_width)),
     )
 
     # central waveguides

--- a/lnoi400/cells.py
+++ b/lnoi400/cells.py
@@ -1002,7 +1002,6 @@ def directional_coupler_balanced(
     coupl_wg_sep: float = 0.8,
     coup_wg_width: float = 0.8,
     cross_section_io: CrossSectionSpec = "xs_rwg1000",
-
 ) -> gf.Component:
     """Returns a 50-50 directional coupler.
 
@@ -1029,7 +1028,7 @@ def directional_coupler_balanced(
     cross_section_io = gf.get_cross_section(cross_section_io)
 
     s_height = (
-        io_wg_sep - coupl_wg_sep -  coup_wg_width
+        io_wg_sep - coupl_wg_sep - coup_wg_width
     ) / 2  # take into account the width of the waveguide
     size = (sbend_length, s_height)
 
@@ -1045,7 +1044,7 @@ def directional_coupler_balanced(
     c_tr = dc << bend_S_spline_varying_width(**settings_s_bend)
     c_tr.dmove(
         c_tr.ports["o1"].dcenter,
-        (central_straight_length / 2, 0.5 * (coupl_wg_sep +  coup_wg_width)),
+        (central_straight_length / 2, 0.5 * (coupl_wg_sep + coup_wg_width)),
     )
 
     # bottom right branch
@@ -1053,7 +1052,7 @@ def directional_coupler_balanced(
     c_br.dmirror_y()
     c_br.dmove(
         c_br.ports["o1"].dcenter,
-        (central_straight_length / 2, -0.5 * (coupl_wg_sep +  coup_wg_width)),
+        (central_straight_length / 2, -0.5 * (coupl_wg_sep + coup_wg_width)),
     )
 
     # central waveguides

--- a/tests/test_components/test_settings_directional_coupler_balanced_.yml
+++ b/tests/test_components/test_settings_directional_coupler_balanced_.yml
@@ -1,10 +1,9 @@
 info: {}
-name: directional_coupler_bal_e7ad1370
+name: directional_coupler_bal_e88e65ac
 settings:
   central_straight_length: 16.92
   coup_wg_width: 0.8
   coupl_wg_sep: 0.8
-  coupling_section_width: 0.8
   cross_section_io: xs_rwg1000
   io_wg_sep: 30.6
   sbend_length: 58


### PR DESCRIPTION
Corrected the distances in the coupling region

## Summary by Sourcery

Bug Fixes:
- Correct the calculation of the s_height and positioning of components in the directional coupler by using coup_wg_width instead of the removed coupling_section_width parameter.