### PR TITLE
Fix notebook title

### DIFF
--- a/docs/notebooks/circuit_layout_ltoi300.ipynb
+++ b/docs/notebooks/circuit_layout_ltoi300.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "## Circuit layout\n",
+    "## Sample circuit layout with ltoi300 PDK\n",
     "\n",
     "Here we provide an example of PIC layout with the ltoi300 PDK. We start by\n",
     "choosing a die floorplan compatible with a submission for an LXT MPW run,\n",
@@ -684,7 +684,7 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "ltoi3000",
+   "display_name": "gf-pdk-dev",
    "language": "python",
    "name": "python3"
   },
@@ -698,7 +698,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/models.ipynb
+++ b/docs/notebooks/models.ipynb
@@ -244,41 +244,6 @@
     "plt.xlabel(\"Voltage (V)\")\n",
     "_ = plt.ylabel(\"MZM transmission\")"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Simulation of ring cavity transmission on ltoi300"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import ltoi300\n",
-    "\n",
-    "pcell_models = ltoi300.get_pdk().models\n",
-    "\n",
-    "mmi_model = pcell_models[\"mmi1x2_oband\"]\n",
-    "\n",
-    "_ = gs.plot_model(\n",
-    "    mmi_model,\n",
-    "    wavelength_start=1.26,\n",
-    "    wavelength_stop=1.36,\n",
-    "    port1=\"o1\",\n",
-    "    ports2=(\"o2\", \"o3\"),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary by Sourcery

Update ltoi300 documentation notebooks to improve titles and environment metadata.

Documentation:
- Clarify the ltoi300 circuit layout notebook title to better describe its contents.

Chores:
- Remove an unused simulation section from the models notebook and refresh kernelspec and Python version metadata in the ltoi300 circuit layout notebook.